### PR TITLE
Fix RFTools conflicting recipe

### DIFF
--- a/scripts/rftools.zs
+++ b/scripts/rftools.zs
@@ -527,7 +527,7 @@ assembler.recipeBuilder()
 
 recipes.remove(redstoneReceiver);
 recipes.addShaped(redstoneReceiver, [
-	[null, mvEmitter, null],
+	[null, mvSensor, null],
 	[null, redstoneWire, null],
 	[null, o_enderPearl, null]]);
 recipes.addShapeless(redstoneReceiver, [redstoneReceiver]);


### PR DESCRIPTION
The redstone receiver and redstone transmitter had the same recipe, this just replaces the emitter in the receiver with a sensor (which makes more sense)